### PR TITLE
Record spider settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ For security reasons, Autounit already excludes `Authorization` and `Proxy-Autho
 If you want to include `Authorization` or `Proxy-Authorization` headers in your fixtures, add one or both of them to this list.  
 `Default: []`
 
+**AUTOUNIT_INCLUDED_SETTINGS**
+Sets a list of settings names to be recorded in the generated test case.
+`Default: []`
+
 **AUTOUNIT_COMPRESS**  
 Enables compression for responses and results in fixtures.  
 Can be useful to reduce fixtures file size if your spiders' responses are too big.  

--- a/scrapy_autounit/middleware.py
+++ b/scrapy_autounit/middleware.py
@@ -13,8 +13,15 @@ from .utils import (
     get_autounit_base_path,
     write_test,
     get_spider_args,
-    get_settings
 )
+
+
+def _copy_settings(settings):
+    out = {}
+    print(settings.attributes.keys())
+    for name in settings.getlist('AUTOUNIT_INCLUDED_SETTINGS', []):
+        out[name] = settings.get(name)
+    return out
 
 
 class AutounitMiddleware:
@@ -45,7 +52,7 @@ class AutounitMiddleware:
         write_test(path)
 
     def process_spider_input(self, response, spider):
-        settings = get_settings(spider)
+        settings = spider.settings
         response.meta['_autounit'] = {
             'request': parse_request(response.request, spider, settings),
             'response': response_to_dict(response, spider, settings),
@@ -54,7 +61,7 @@ class AutounitMiddleware:
         return None
 
     def process_spider_output(self, response, result, spider):
-        settings = get_settings(spider)
+        settings = spider.settings
 
         processed_result = []
         out = []
@@ -74,7 +81,8 @@ class AutounitMiddleware:
             'request': request,
             'response': input_data['response'],
             'result': processed_result,
-            'spider_args': input_data['spider_args']
+            'spider_args': input_data['spider_args'],
+            'settings': _copy_settings(settings),
         }
 
         callback_counter = self.fixture_counters.setdefault(callback_name, 0)

--- a/scrapy_autounit/utils.py
+++ b/scrapy_autounit/utils.py
@@ -16,9 +16,6 @@ from scrapy.utils.project import get_project_settings
 from scrapy.utils.conf import init_env, closest_scrapy_cfg
 
 
-    settings = get_project_settings()
-
-
 def get_project_dir():
     closest_cfg = closest_scrapy_cfg()
     if closest_cfg:
@@ -77,7 +74,7 @@ def unpickle_data(data):
     return pickle.loads(b64decode(data))
 
 
-def response_to_dict(response, settings):
+def response_to_dict(response):
     return {
         'url': response.url,
         'status': response.status,
@@ -87,7 +84,7 @@ def response_to_dict(response, settings):
     }
 
 
-def get_spider_class(project_settings, spider_name):
+def get_spider_class(spider_name, project_settings):
     spider_modules = project_settings.get('SPIDER_MODULES')
     for spider_module in spider_modules:
         modules = walk_modules(spider_module)
@@ -98,31 +95,31 @@ def get_spider_class(project_settings, spider_name):
     return None
 
 
-def parse_object(_object, spider, settings):
+def parse_object(_object, spider):
     if isinstance(_object, Request):
-        return parse_request(_object, spider, settings)
+        return parse_request(_object, spider)
 
     if isinstance(_object, (dict, Item)):
         _object = _object.copy()
-        clean_item(_object, settings)
+        clean_item(_object, spider.settings)
 
     return _object
 
 
-def parse_request(request, spider, settings):
+def parse_request(request, spider):
     _request = request_to_dict(request, spider=spider)
     if not _request['callback']:
         _request['callback'] = 'parse'
 
-    clean_headers(_request['headers'], settings)
+    clean_headers(_request['headers'], spider.settings)
     _request['body'] = _request['body'].decode('utf-8')
 
     _meta = {}
     for key, value in _request.get('meta').items():
-        _meta[key] = parse_object(value, spider, settings)
+        _meta[key] = parse_object(value, spider)
     _request['meta'] = _meta
 
-    clean_request(_request, settings)
+    clean_request(_request, spider.settings)
 
     return _request
 
@@ -130,7 +127,6 @@ def parse_request(request, spider, settings):
 def clean_request(request, settings):
     _clean(request, settings, 'AUTOUNIT_REQUEST_SKIPPED_FIELDS')
 
-        'AUTOUNIT_EXCLUDED_HEADERS', default=[])
 
 def clean_headers(headers, settings):
     excluded = settings.get('AUTOUNIT_EXCLUDED_HEADERS', default=[])
@@ -141,8 +137,6 @@ def clean_headers(headers, settings):
         headers.pop(header, None)
         headers.pop(header.encode(), None)
 
-    skipped_fields = spider.settings.get(
-        'AUTOUNIT_SKIPPED_FIELDS', default=[])
 
 def clean_item(item, settings):
     _clean(item, settings, 'AUTOUNIT_EXCLUDED_FIELDS')
@@ -212,18 +206,14 @@ def test_generator(fixture_path):
     spider_name = fixture_path.parent.parent.name
 
     settings = get_project_settings()
-    for k, v in data.get('settings', {}).items():
-        settings.set(k, v, 50)
 
     spider_cls = get_spider_class(spider_name, settings)
-
-    spider_cls = get_spider_class(settings, spider_name)
     spider_cls.update_settings(settings)
+    for k, v in data.get('settings', {}).items():
+        settings.set(k, v, 50)
     spider = spider_cls(**data.get('spider_args'))
     spider.settings = settings
     callback = getattr(spider, callback_name, None)
-
-    merge_settings(settings, spider)
 
     def test(self):
         fixture_objects = data['result']
@@ -250,7 +240,7 @@ def test_generator(fixture_path):
             else:
                 clean_item(fixture_data, settings)
 
-            _object = parse_object(_object, spider, settings)
+            _object = parse_object(_object, spider)
             self.assertEqual(fixture_data, _object, 'Not equal!')
 
     return test


### PR DESCRIPTION
I also tried to reduce the calls to get_project_settings because I was worried that sometimes the settings would contain the recorded settings and sometimes it would just have the normal settings and could create confusing issues...

I made `spider.settings` the canonical source for settings.  This also allowed me to remove some parameters.