### PR TITLE
Fix #19: Use datadiff to show diffs on output

### DIFF
--- a/scrapy_autounit/utils.py
+++ b/scrapy_autounit/utils.py
@@ -326,8 +326,10 @@ def generate_test(fixture_path, encoding='utf-8'):
             try:
                 datadiff.tools.assert_equal(fx_obj, cb_obj)
             except AssertionError as e:
-                raise AssertionError(
-                    "Callback output #{} doesn't match recorded "
-                    "output:{}".format(index, e))
+                six.raise_from(
+                    AssertionError(
+                        "Callback output #{} doesn't match recorded "
+                        "output:{}".format(index, e)),
+                    None)
 
     return test

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,6 @@ setuptools.setup(
     ],
     install_requires=[
         'pathlib',
+        'datadiff==2.0.0',
     ],
 )


### PR DESCRIPTION
Here's an example error message from before:
```
AssertionError: Unit tests failed!
STDOUT--

STDERR--
    test__myspider__parse__fixture1 (autounit.tests.myspider.parse.test_fixture1.AutoUnit) ... FAIL
    test__myspider__parse__fixture2 (autounit.tests.myspider.parse.test_fixture2.AutoUnit) ... ok
    
    ======================================================================
    FAIL: test__myspider__parse__fixture1 (autounit.tests.myspider.parse.test_fixture1.AutoUnit)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/tmp/tmpdto_xpie/autounit/tests/myspider/parse/test_fixture1.py", line 13, in test__myspider__parse__fixture1
        test(self)
      File "/home/andrew/scraping/scrapy-autounit/scrapy_autounit/utils.py", line 325, in test
        self.assertEqual(fx_obj, cb_obj, 'Not equal!')
    AssertionError: {'url[172 chars]ng': 'utf-8', 'priority': 0, 'dont_filter': False, 'flags': []} != {'url[172 chars]ng': 'utf-8', 'priority': 0, 'dont_filter': False, 'flags': []}
      {'_encoding': 'utf-8',
       'body': b'',
       'callback': 'parse',
       'cookies': {},
       'dont_filter': False,
       'errback': None,
       'flags': [],
       'headers': {},
       'meta': {'data': <200 data:text/plain,>},
       'method': 'GET',
       'priority': 0,
       'url': 'data:text/plain,1'} : Not equal!
    
    ----------------------------------------------------------------------
    Ran 2 tests in 0.027s
    
    FAILED (failures=1)
```

And with datadiff:
```
STDOUT--

STDERR--
    test__myspider__parse__fixture1 (autounit.tests.myspider.parse.test_fixture1.AutoUnit) ... FAIL
    test__myspider__parse__fixture2 (autounit.tests.myspider.parse.test_fixture2.AutoUnit) ... ok
    
    ======================================================================
    FAIL: test__myspider__parse__fixture1 (autounit.tests.myspider.parse.test_fixture1.AutoUnit)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/tmp/tmplxypykkl/autounit/tests/myspider/parse/test_fixture1.py", line 13, in test__myspider__parse__fixture1
        test(self)
      File "/home/andrew/scraping/scrapy-autounit/scrapy_autounit/utils.py", line 333, in test
        None)
      File "<string>", line 3, in raise_from
    AssertionError: Callback output #0 doesn't match recorded output:
    --- a
    +++ b
    {
     '_encoding': 'utf-8',
     'body': b'',
     'callback': 'parse',
     'cookies': {},
     'dont_filter': False,
     'errback': None,
     'flags': [],
     'headers': {},
     'meta': {
     -'data': <200 data:text/plain,>,
     +'data': <200 data:text/plain,>,
     @@  @@
     },
     'priority': 0,
     'url': 'data:text/plain,1',
    @@  @@
    }
    
    ----------------------------------------------------------------------
    Ran 2 tests in 0.027s
    
    FAILED (failures=1)
```

Unfortunately it's not perfectly clear what's going on here but `<200 data...>` is the repr of the request I think and the requests are not equal so it's failing.  But for dictionaries and lists it will highlight the exact field.