### PR TITLE
[xml] Fixes #60: detect type of request to build the response

### DIFF
--- a/scrapy_autounit/utils.py
+++ b/scrapy_autounit/utils.py
@@ -290,11 +290,15 @@ def generate_test(fixture_path, encoding='utf-8'):
         fx_version = data.get('python_version')
 
         request = request_from_dict(data['request'], spider)
-        if re.findall(r'text\/html', request.headers['Accept'].decode('utf8')):
-            response = HtmlResponse(request=request, **data['response'])
-        elif re.findall(r'text\/xml',
-                        request.headers['Accept'].decode('utf8')):
+        if re.findall(r'(text\/xml|application\/xhtml\+xml|application\/xml)',
+                      request.headers['Accept'].decode('utf8')):
             response = XmlResponse(request=request, **data['response'])
+        elif re.findall(r'text\/html',
+                        request.headers['Accept'].decode('utf8')):
+            response = HtmlResponse(request=request, **data['response'])
+        else:
+            raise TypeError(
+                'Type of request not found for request %s' % request)
 
         middlewares = []
         middleware_paths = data['middlewares']

--- a/scrapy_autounit/utils.py
+++ b/scrapy_autounit/utils.py
@@ -1,4 +1,5 @@
 import os
+import re
 import six
 import sys
 import zlib
@@ -11,7 +12,7 @@ from scrapy import signals
 from scrapy.item import Item
 from scrapy.crawler import Crawler
 from scrapy.exceptions import NotConfigured
-from scrapy.http import HtmlResponse, Request, Response
+from scrapy.http import HtmlResponse, Request, Response, XmlResponse
 from scrapy.utils.python import to_bytes
 from scrapy.utils.reqser import request_to_dict, request_from_dict
 from scrapy.utils.spider import iter_spider_classes
@@ -289,7 +290,11 @@ def generate_test(fixture_path, encoding='utf-8'):
         fx_version = data.get('python_version')
 
         request = request_from_dict(data['request'], spider)
-        response = HtmlResponse(request=request, **data['response'])
+        if re.findall(r'text\/html', request.headers['Accept'].decode('utf8')):
+            response = HtmlResponse(request=request, **data['response'])
+        elif re.findall(r'text\/xml',
+                        request.headers['Accept'].decode('utf8')):
+            response = XmlResponse(request=request, **data['response'])
 
         middlewares = []
         middleware_paths = data['middlewares']

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -257,3 +257,43 @@ class TestRecording(unittest.TestCase):
             ''')
             spider.record()
             spider.test()
+
+    def test_html_response(self):
+        with CaseSpider() as spider:
+            spider.start_requests('''
+                yield scrapy.Request(
+                    'data:text/html,'
+                    '<div><link><p>text_html</p></link></div>'
+                )
+            ''')
+            spider.parse('''
+                yield {
+                    'v': response.css('div > link > p::text').get()
+                }
+            ''')
+            spider.record()
+            spider.test()
+
+    def test_xml_response(self):
+        with CaseSpider() as spider:
+            spider.start_requests('''
+                yield scrapy.Request(
+                    'data:text/xml,'
+                    """
+                    <?xml version="1.0" encoding="UTF-8"?>
+                        <note>
+                            <to>Scrapinghub</to>
+                            <from>Somebody</from>
+                            <heading>Reminder</heading>
+                            <body>Newsletter...</body>
+                            </note>
+                    """ 
+                )
+            ''')
+            spider.parse('''
+                yield {
+                    'v': response.css('div > link > p::text').get()
+                }
+            ''')
+            spider.record()
+            spider.test()


### PR DESCRIPTION
Fixes #60 
Detect the type of request and distinguish between `HtmlResponse` and `XmlResponse`.