### PR TITLE
Avoid pickling exceptions

### DIFF
--- a/scrapy_autounit/middleware.py
+++ b/scrapy_autounit/middleware.py
@@ -73,11 +73,12 @@ class AutounitMiddleware:
         return cls(crawler)
 
     def process_spider_input(self, response, spider):
+        d = spider.__getstate__() if hasattr(spider, '__getstate__') else spider.__dict__
         response.meta['_autounit'] = pickle.dumps({
             'request': parse_request(response.request, spider),
             'response': response_to_dict(response),
             'spider_args': {
-                k: v for k, v in spider.__dict__.items()
+                k: v for k, v in d.items()
                 if k not in get_filter_attrs(spider)
             },
             'middlewares': get_middlewares(spider),
@@ -93,8 +94,9 @@ class AutounitMiddleware:
 
         request = input_data['request']
         callback_name = request['callback']
+        d = spider.__getstate__() if hasattr(spider, '__getstate__') else spider.__dict__
         spider_attr_out = {
-            k: v for k, v in spider.__dict__.items()
+            k: v for k, v in d.items()
             if k not in get_filter_attrs(spider)
         }
 

--- a/scrapy_autounit/utils.py
+++ b/scrapy_autounit/utils.py
@@ -385,8 +385,9 @@ def generate_test(fixture_path, encoding='utf-8'):
             signal=signals.spider_opened,
             spider=spider
         )
+        d = spider.__getstate__() if hasattr(spider, '__getstate__') else spider.__dict__
         result_attr_in = {
-            k: v for k, v in spider.__dict__.items()
+            k: v for k, v in d.items()
             if k not in get_filter_attrs(spider)
         }
         self.assertEqual(spider_args_in, result_attr_in,
@@ -437,8 +438,9 @@ def generate_test(fixture_path, encoding='utf-8'):
                     None)
 
         # Spider attributes get updated after the yield
+        d = spider.__getstate__() if hasattr(spider, '__getstate__') else spider.__dict__
         result_attr_out = {
-            k: v for k, v in spider.__dict__.items()
+            k: v for k, v in d.items()
             if k not in get_filter_attrs(spider)
         }
 


### PR DESCRIPTION
This fixes https://github.com/scrapinghub/scrapy-autounit/issues/74.

I missed the fact that a fix was made in scrapy proper for my specific `LinkExtractor` pickling problem, and in the meantime,  made a more general fix to scrapy-autounit.

Since pickling calls an object's `__getstate__` method to serialize, I thought scrapy-autounit should as well. This change calls `spider.__getstate__()`, or falls back to otherwise using `spider.__dict__`. Any spider that can't be pickled—for having a `LinkExtractor` as an attribute or something unforeseen in the future—can implement something like this to avoid the problem:

```
def __getstate__(self):
    state = self.__dict__.copy()
    state.pop('offending_attribute')
    return state
```