### PR TITLE
Filter input and output attributes  #77

### DIFF
--- a/scrapy_autounit/utils.py
+++ b/scrapy_autounit/utils.py
@@ -226,6 +226,9 @@ def clean_item(item, settings):
 
 def _clean(data, settings, name):
     fields = settings.get(name, default=[])
+    assert isinstance(fields, list), \
+        f"Autounit setting '{name}' must be a list, "\
+        f"found type '{type(fields)}' ('{fields}')"
     for field in fields:
         data.pop(field, None)
 

--- a/scrapy_autounit/utils.py
+++ b/scrapy_autounit/utils.py
@@ -95,7 +95,7 @@ def get_or_create_test_dir(base_path, spider_name, callback_name, extra=None):
         test_dir = os.path.join(test_dir, component) if test_dir else component
         create_dir(test_dir, parents=True, exist_ok=True)
         init_file = os.path.join(test_dir, '__init__.py')
-        with open(init_file, 'a'):
+        with open(init_file, 'a+'):
             os.utime(init_file, None)
     test_name = '__'.join(components[2:])
     return test_dir, test_name

--- a/scrapy_autounit/utils.py
+++ b/scrapy_autounit/utils.py
@@ -365,6 +365,7 @@ def generate_test(fixture_path, encoding='utf-8'):
 
         spider_args_in = data.get(
             'spider_args', data.get('spider_args_in', {}))
+        _clean(spider_args_in, settings, 'AUTOUNIT_SKIPPED_FIELDS')
         set_spider_attrs(spider, spider_args_in)
         request = request_from_dict(data['request'], spider)
         response_cls = auto_import(data['response'].pop(
@@ -389,6 +390,7 @@ def generate_test(fixture_path, encoding='utf-8'):
             k: v for k, v in spider.__dict__.items()
             if k not in get_filter_attrs(spider)
         }
+        _clean(result_attr_in, settings, 'AUTOUNIT_SKIPPED_FIELDS')
         self.assertEqual(spider_args_in, result_attr_in,
                          'Input arguments not equal!')
 
@@ -441,7 +443,9 @@ def generate_test(fixture_path, encoding='utf-8'):
             k: v for k, v in spider.__dict__.items()
             if k not in get_filter_attrs(spider)
         }
-
-        self.assertEqual(data['spider_args_out'], result_attr_out,
+        _clean(result_attr_out, settings, 'AUTOUNIT_SKIPPED_FIELDS')
+        spider_args_out = data['spider_args_out']
+        _clean(data['spider_args_out'], settings, 'AUTOUNIT_SKIPPED_FIELDS')
+        self.assertEqual(spider_args_out, result_attr_out,
                          'Output arguments not equal!')
     return test

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -232,6 +232,7 @@ class TestRecording(unittest.TestCase):
         with CaseSpider() as spider:
             spider.start_requests("""
                 self._base_url = 'www.nothing.com'
+                self.param = 0
                 yield scrapy.Request('data:text/plain,')
             """)
             spider.parse("""
@@ -250,9 +251,22 @@ class TestRecording(unittest.TestCase):
                 self.param = 1
                 yield {'a': 4}
             """)
-            spider.record(settings=dict(
-                AUTOUNIT_EXCLUDED_FIELDS='_base_url',
-                AUTOUNIT_INCLUDED_SETTINGS='AUTOUNIT_EXCLUDED_FIELDS'))
+            spider.record(settings={
+                'AUTOUNIT_SKIPPED_FIELDS': '_base_url',
+                'AUTOUNIT_INCLUDED_SETTINGS': 'AUTOUNIT_SKIPPED_FIELDS'})
+            spider.test()
+
+        with CaseSpider() as spider:
+            spider.start_requests("""
+                self.values = ['a', 'b']
+                self.mapping = filter(None, self.values)
+                yield scrapy.Request('data:text/plain,')
+            """)
+            spider.parse("""
+                yield {'a': 4}
+            """)
+            spider.record(settings={
+                'AUTOUNIT_SKIPPED_FIELDS': ['mapping']})
             spider.test()
 
     def test_spider_attributes_recursive(self):


### PR DESCRIPTION
# What has been done
- Used the `_clean` function from utils to filter spider attributes.

TODO:
- [] Add tests
## Discussion 
- Maybe we could add a new field so it can be a separate filter from `AUTOUNIT_SKIPPED_FIELDS`, something like `AUTOUNIT_SKIPPED_SPIDER_ATTRIBUTES`.

Fixes #77 