### PR TITLE
Fix parse_object() for tuples

### DIFF
--- a/scrapy_autounit/utils.py
+++ b/scrapy_autounit/utils.py
@@ -180,9 +180,11 @@ def parse_object(_object, spider):
     elif isinstance(_object, dict):
         for k, v in _object.items():
             _object[k] = parse_object(v, spider)
-    elif isinstance(_object, (list, tuple)):
+    elif isinstance(_object, list):
         for i, v in enumerate(_object):
             _object[i] = parse_object(v, spider)
+    elif isinstance(_object, tuple):
+        _object = tuple([parse_object(o, spider) for o in _object])
     return _object
 
 

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -380,6 +380,22 @@ class TestRecording(unittest.TestCase):
             spider.record()
             spider.test()
 
+    def test_request_parsing_types_meta_in_output(self):
+        with CaseSpider() as spider:
+            spider.start_requests('''
+                yield scrapy.Request(
+                    'data:text/plain,',
+                    meta={'metadata': [
+                        ('tuples', {'dicts': 'and'}, ['lists', 'in'], 'meta', 1, 20.5)
+                    ]}
+                )
+            ''')
+            spider.parse('''
+                yield {'data': response.request}
+            ''')
+            spider.record()
+            spider.test()
+
     def test_nested_response_in_output(self):
         with CaseSpider() as spider:
             spider.start_requests('''


### PR DESCRIPTION
In one of my project we pass tuples in meta, which breaks the current parsing with beautiful:

`_object[i] = parse_object(v, spider)`
`TypeError: 'tuple' object does not support item assignment`

This PR fixes tuple handling and adds a test for several types usually passed in meta.