### PR TITLE
Add AUTOUNIT_SKIP_SPIDER_ATTRIBUTES setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ Sets a list of request fields to be skipped when running your tests.
 Similar to AUTOUNIT_SKIPPED_FIELDS but applied to requests instead of items.  
 `Default: []`
 
+**AUTOUNIT_SKIP_SPIDER_ATTRIBUTES**  
+Sets a list of spider attributes to be skipped when recording and running your tests.  
+This setting can be used to prevent pickling errors with more complicated spiders, e.g. in `SitemapSpider`.
+`Default: []`
+
 **AUTOUNIT_EXCLUDED_HEADERS**  
 Sets a list of headers to exclude from requests recording.  
 For security reasons, Autounit already excludes `Authorization` and `Proxy-Authorization` headers by default, if you want to include them in your fixtures see *`AUTOUNIT_INCLUDED_AUTH_HEADERS`*.  

--- a/scrapy_autounit/utils.py
+++ b/scrapy_autounit/utils.py
@@ -103,9 +103,10 @@ def get_or_create_test_dir(base_path, spider_name, callback_name, extra=None):
 
 def get_filter_attrs(spider):
     attrs = {'crawler', 'settings', 'start_urls'}
+    custom_skipped_attrs = set(spider.settings.getlist("AUTOUNIT_SKIP_SPIDER_ATTRIBUTES"))
     if isinstance(spider, CrawlSpider):
         attrs |= {'rules', '_rules'}
-    return attrs
+    return attrs.union(custom_skipped_attrs)
 
 
 def add_sample(index, test_dir, test_name, data):

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -523,3 +523,14 @@ class TestRecording(unittest.TestCase):
             """)
             with self.assertRaises(AssertionError):
                 spider.record()
+
+    def test_skip_spider_attribute(self):
+        spider = CaseSpider()
+        spider.unpickleable_attribute = lambda x: 'some unpickleable lambda'
+        spider.parse("""
+            yield scrapy.Request('data:text/plain,')
+        """)
+        with self.assertRaises(AssertionError):
+            spider.record(settings={
+                "AUTOUNIT_SKIP_SPIDER_ATTRIBUTES": ['unpickleable_attribute']
+            })


### PR DESCRIPTION
Some spiders (e.g. `SitemapSpider`) contain unpickleable attributes that can't be stored in the test fixture by the middleware.
If those attributes aren't required to record/replay autounit tests, they could simply be ignored during recording, and that's what `AUTOUNIT_SKIP_SPIDER_ATTRIBUTES` setting could be for.

For `SitemapSpider`, that would be
`AUTOUNIT_SKIP_SPIDER_ATTRIBUTES = ['_cbs']`
