### PR TITLE
change warn to warning to avoid a DeprecationWarning

### DIFF
--- a/scrapy_autounit/middleware.py
+++ b/scrapy_autounit/middleware.py
@@ -23,7 +23,7 @@ class AutounitMiddleware:
             raise NotConfigured('scrapy-autounit is not enabled')
 
         if settings.getint('CONCURRENT_REQUESTS') > 1:
-            logger.warn(
+            logger.warning(
                 'Recording with concurrency > 1! '
                 'Data races in shared object modification may create broken tests.'
             )


### PR DESCRIPTION
This `warn` is causing the next deprecation warning: 

`DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead`